### PR TITLE
Fix global syntax error

### DIFF
--- a/universalclient/universalclient.py
+++ b/universalclient/universalclient.py
@@ -24,6 +24,10 @@ class Client(object):
         _getattr = super(Client, self).__getattribute__
         attributes = _getattr("_attributes")
         attributes = deepcopy(attributes)
+        # Hack to get around global keyword issue where client.endpoint.global.test.method() 
+        # throws a syntax error
+        if name == "global_":
+            name = "global"
         attributes["_path"].append(name)
         attributes["oauth"] = _getattr("_http")
         return Client(**attributes)


### PR DESCRIPTION
If I have an endpoint like: /my/endpoint/global/test, you will get "SyntaxError: invalid syntax" when you try to call client.endpoint.global.test.get() because global is a protected keyword in Python. 

My workaround is to use global_ instead. [e.g. client.endpoint.global_.test.get() instead of client.endpoint.global.test.get()]
